### PR TITLE
Made changes to account for matplotlib update

### DIFF
--- a/ebm/plotting/plotting.py
+++ b/ebm/plotting/plotting.py
@@ -38,7 +38,7 @@ def mixture_model_grid(X, y, mixtures,
         hist_c = colors[:2]
         leg1 = ax[i // n_x, i % n_x].hist(hist_dat,
                                           label=class_names,
-                                          normed=True,
+                                          density=True,
                                           color=hist_c,
                                           alpha=0.7,
                                           stacked=True)
@@ -123,13 +123,13 @@ def stage_histogram(stages, y, max_stage=None, class_names=None):
     hist_c = colors[:2]
     n, bins, patch = ax.hist(hist_dat,
                              label=class_names,
-                             normed=True,
+                             density=True,
                              color=hist_c,
                              stacked=False,
                              bins=max_stage+1)
     ax.legend(loc=0, fontsize=20)
 
-    idxs = np.arange(max_stage+1)
+    idxs = np.arange(max_stage+2)
     bin_w = bins[1] - bins[0]
     ax.set_xticks(bins+bin_w/2)
     ax.set_xticklabels([str(x) for x in idxs])


### PR DESCRIPTION
Matplotlib has made several changes to the way their histograms are made. This caused the example.py script that was provided not to work for me anymore. The small changes I adjusted for, fixed this issue.